### PR TITLE
Implement remote dismissal

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.5.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'com.onesignal:OneSignal:[5.0.0-beta, 5.99.99]'
+    implementation 'com.onesignal:OneSignal:[5.1.8, 5.99.99]'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,6 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,5 +25,6 @@
             </intent-filter>
         </activity>
     </application>
+    <uses-permission android:name="android.permission.INTERNET" />
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,8 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.OneSignalAndroidSample"
         tools:targetApi="31">
+        <meta-data android:name="com.onesignal.NotificationServiceExtension"
+            android:value="com.onesignal.sample.android.NotificationServiceExtension" />
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
             </intent-filter>
         </activity>
     </application>
-    <uses-permission android:name="android.permission.INTERNET" />
+<!--    <uses-permission android:name="android.permission.INTERNET"-->
+<!--        android:maxSdkVersion="18" />-->
 
 </manifest>

--- a/app/src/main/java/com/onesignal/sample/android/MainActivity.kt
+++ b/app/src/main/java/com/onesignal/sample/android/MainActivity.kt
@@ -11,7 +11,7 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
 
         findViewById<Button>(R.id.login).setOnClickListener {
-            OneSignal.login("USER_ID")
+            OneSignal.login("elly")
         }
 
         findViewById<Button>(R.id.logout).setOnClickListener {

--- a/app/src/main/java/com/onesignal/sample/android/MainApplication.kt
+++ b/app/src/main/java/com/onesignal/sample/android/MainApplication.kt
@@ -3,7 +3,7 @@ import android.app.Application
 import com.onesignal.OneSignal
 import com.onesignal.debug.LogLevel
 
-const val ONESIGNAL_APP_ID = "YOUR_APP_ID_HERE"
+const val ONESIGNAL_APP_ID = "5e605fcd-de88-4b0a-a5eb-5c18b84d52f3"
 
 class MainApplication : Application() {
     override fun onCreate() {

--- a/app/src/main/java/com/onesignal/sample/android/NotificationServiceExtension.java
+++ b/app/src/main/java/com/onesignal/sample/android/NotificationServiceExtension.java
@@ -1,0 +1,27 @@
+package com.onesignal.sample.android;
+
+import com.onesignal.notifications.IActionButton;
+import com.onesignal.notifications.IDisplayableMutableNotification;
+import com.onesignal.notifications.INotificationReceivedEvent;
+import com.onesignal.notifications.INotificationServiceExtension;
+
+public class NotificationServiceExtension implements INotificationServiceExtension {
+    @Override
+    public void onNotificationReceived(INotificationReceivedEvent event) {
+        IDisplayableMutableNotification notification = event.getNotification();
+
+        if (notification.getActionButtons() != null) {
+            for (IActionButton button : notification.getActionButtons()) {
+                // you can modify your action buttons here
+            }
+        }
+
+        // this is an example of how to modify the notification by changing the background color to blue
+        notification.setExtender(builder -> builder.setColor(0xFF0000FF));
+        notification.setExtender(builder -> builder.setAutoCancel(false));
+
+        //If you need to perform an async action or stop the payload from being shown automatically,
+        //use event.preventDefault(). Using event.notification.display() will show this message again.
+    }
+}
+

--- a/app/src/main/java/com/onesignal/sample/android/NotificationServiceExtension.java
+++ b/app/src/main/java/com/onesignal/sample/android/NotificationServiceExtension.java
@@ -12,23 +12,30 @@ import com.onesignal.notifications.IDisplayableMutableNotification;
 import com.onesignal.notifications.INotificationReceivedEvent;
 import com.onesignal.notifications.INotificationServiceExtension;
 
+import org.json.JSONException;
+
 public class NotificationServiceExtension implements INotificationServiceExtension {
     private static final String CHANNEL_ID = "progress_channel";
 
     @Override
     public void onNotificationReceived(INotificationReceivedEvent event) {
         IDisplayableMutableNotification notification = event.getNotification();
-
+        try {
+            String William = notification.getAdditionalData().get("live_notification_key").toString();
+            System.out.println(William);
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
         Context context = event.getContext(); // Assuming there's a way to obtain context
         createNotificationChannel(context);
 
         // Simulated download progress
         int progressMax = 100;
-        int currentProgress = 30; // This would be dynamically updated in a real scenario
+        int currentProgress = 50; // This would be dynamically updated in a real scenario
 
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context, CHANNEL_ID)
-                .setContentTitle("Download in progress")
-                .setContentText("Downloading...")
+                .setContentTitle("Android Live Notifications is in progress")
+                .setContentText("Elly is working...")
                 .setSmallIcon(android.R.drawable.ic_media_play)
                 .setLargeIcon(BitmapFactory.decodeResource(context.getResources(), android.R.drawable.ic_dialog_info))
                 .setOngoing(true)

--- a/app/src/main/java/com/onesignal/sample/android/NotificationServiceExtension.java
+++ b/app/src/main/java/com/onesignal/sample/android/NotificationServiceExtension.java
@@ -1,27 +1,57 @@
 package com.onesignal.sample.android;
 
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.graphics.BitmapFactory;
+import android.os.Build;
+import androidx.core.app.NotificationCompat;
+
 import com.onesignal.notifications.IActionButton;
 import com.onesignal.notifications.IDisplayableMutableNotification;
 import com.onesignal.notifications.INotificationReceivedEvent;
 import com.onesignal.notifications.INotificationServiceExtension;
 
 public class NotificationServiceExtension implements INotificationServiceExtension {
+    private static final String CHANNEL_ID = "progress_channel";
+
     @Override
     public void onNotificationReceived(INotificationReceivedEvent event) {
         IDisplayableMutableNotification notification = event.getNotification();
 
-        if (notification.getActionButtons() != null) {
-            for (IActionButton button : notification.getActionButtons()) {
-                // you can modify your action buttons here
-            }
+        Context context = event.getContext(); // Assuming there's a way to obtain context
+        createNotificationChannel(context);
+
+        // Simulated download progress
+        int progressMax = 100;
+        int currentProgress = 30; // This would be dynamically updated in a real scenario
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, CHANNEL_ID)
+                .setContentTitle("Download in progress")
+                .setContentText("Downloading...")
+                .setSmallIcon(android.R.drawable.ic_media_play)
+                .setLargeIcon(BitmapFactory.decodeResource(context.getResources(), android.R.drawable.ic_dialog_info))
+                .setOngoing(true)
+                .setOnlyAlertOnce(true)
+                .setProgress(progressMax, currentProgress, false);
+
+        NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        notificationManager.notify(1, builder.build()); // ID 1 is arbitrary
+
+        // As the download progresses, you would need to update the progress like so:
+        // builder.setProgress(progressMax, newCurrentProgress, false);
+        // notificationManager.notify(1, builder.build());
+    }
+
+    private void createNotificationChannel(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            CharSequence name = "Progress Notification";
+            String description = "Shows the progress of a download";
+            int importance = NotificationManager.IMPORTANCE_LOW;
+            NotificationChannel channel = new NotificationChannel(CHANNEL_ID, name, importance);
+            channel.setDescription(description);
+            NotificationManager notificationManager = context.getSystemService(NotificationManager.class);
+            notificationManager.createNotificationChannel(channel);
         }
-
-        // this is an example of how to modify the notification by changing the background color to blue
-        notification.setExtender(builder -> builder.setColor(0xFF0000FF));
-        notification.setExtender(builder -> builder.setAutoCancel(false));
-
-        //If you need to perform an async action or stop the payload from being shown automatically,
-        //use event.preventDefault(). Using event.notification.display() will show this message again.
     }
 }
-

--- a/app/src/main/java/com/onesignal/sample/android/NotificationServiceExtension.java
+++ b/app/src/main/java/com/onesignal/sample/android/NotificationServiceExtension.java
@@ -7,7 +7,6 @@ import android.graphics.BitmapFactory;
 import android.os.Build;
 import androidx.core.app.NotificationCompat;
 
-import com.onesignal.notifications.IActionButton;
 import com.onesignal.notifications.IDisplayableMutableNotification;
 import com.onesignal.notifications.INotificationReceivedEvent;
 import com.onesignal.notifications.INotificationServiceExtension;
@@ -16,58 +15,82 @@ import org.json.JSONException;
 
 import java.util.Objects;
 
+/** @noinspection unused*/
 public class NotificationServiceExtension implements INotificationServiceExtension {
-    private static final String CHANNEL_ID = "progress_channel";
+    // Live Notification IDs
+    private static final String PROGRESS_LIVE_NOTIFICATION = "some_id";
+    private static final String ANOTHER_LIVE_NOTIFICATION = "another_id";
+
+    // Channels
+    private static final String PROGRESS_CHANNEL_ID = "progress_channel";
+    private static final String ANOTHER_CHANNEL_ID = "another_channel";
 
     @Override
     public void onNotificationReceived(INotificationReceivedEvent event) {
         IDisplayableMutableNotification notification = event.getNotification();
-        Context context = event.getContext(); // Assuming there's a way to obtain context
-        createNotificationChannel(context);
-        NotificationCompat.Builder builder;
-
+        Context context = event.getContext();
         try {
-            String liveNotificationKey = Objects.requireNonNull(notification.getAdditionalData()).get("live_notification_key").toString();
-            switch (liveNotificationKey) {
-                case "some_id":
-                    int progressMax = 100;
-                    int currentProgress = 50; // This would be dynamically updated in a real scenario
-
-                    builder = new NotificationCompat.Builder(context, CHANNEL_ID)
+            String liveNotificationTypeId = Objects.requireNonNull(notification.getAdditionalData()).getJSONObject("live_notification_key").getString("id");
+            NotificationCompat.Builder builder;
+            switch (liveNotificationTypeId) {
+                case PROGRESS_LIVE_NOTIFICATION:
+                    createNotificationChannel(event.getContext(), liveNotificationTypeId);
+                    int currentProgress = Objects.requireNonNull(notification.getAdditionalData()).getJSONObject("live_notification_key").getInt("current_progress");
+                    builder = new NotificationCompat.Builder(context, PROGRESS_CHANNEL_ID)
                             .setContentTitle("Android Live Notifications is in progress")
                             .setContentText("Elly is working...")
                             .setSmallIcon(android.R.drawable.ic_media_play)
                             .setLargeIcon(BitmapFactory.decodeResource(context.getResources(), android.R.drawable.ic_dialog_info))
                             .setOngoing(true)
                             .setOnlyAlertOnce(true)
-                            .setProgress(progressMax, currentProgress, false);
-
-                    NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-                    notificationManager.notify(1, builder.build()); // ID 1 is arbitrary
-
-                    // As the download progresses, you would need to update the progress like so:
-                    // builder.setProgress(progressMax, newCurrentProgress, false);
-                    // notificationManager.notify(1, builder.build());
+                            .setProgress(100, currentProgress, false);
                     break;
-                case "some_other_id":
+                case ANOTHER_LIVE_NOTIFICATION:
+                    builder = new NotificationCompat.Builder(context, PROGRESS_CHANNEL_ID)
+                            .setContentTitle("Some other Live Notification")
+                            .setContentText("Content goes here")
+                            .setOngoing(true)
+                            .setOnlyAlertOnce(true);
                     break;
                 default:
-                    throw new IllegalStateException("Unsupported Live Notification Key provided: " + liveNotificationKey);
+                    throw new IllegalStateException("Unsupported Live Notification Key provided: " + liveNotificationTypeId);
             }
+
+            NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+            notificationManager.notify(1, builder.build()); // ID 1 is arbitrary
         } catch (JSONException e) {
-            throw new RuntimeException(e);
+            System.err.println(e.getMessage());
         }
     }
 
-    private void createNotificationChannel(Context context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            CharSequence name = "Progress Notification";
-            String description = "Shows the progress of a download";
-            int importance = NotificationManager.IMPORTANCE_LOW;
-            NotificationChannel channel = new NotificationChannel(CHANNEL_ID, name, importance);
-            channel.setDescription(description);
-            NotificationManager notificationManager = context.getSystemService(NotificationManager.class);
-            notificationManager.createNotificationChannel(channel);
+    private void createNotificationChannel(Context context, String liveNotificationTypeId) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
+
+        NotificationManager notificationManager = context.getSystemService(NotificationManager.class);
+        NotificationChannel channel;
+        switch (liveNotificationTypeId) {
+            case PROGRESS_LIVE_NOTIFICATION:
+                NotificationChannel maybeProgressChannel = notificationManager.getNotificationChannel(PROGRESS_CHANNEL_ID);
+                if (maybeProgressChannel == null) {
+                    channel = new NotificationChannel(PROGRESS_CHANNEL_ID, "Progress Live Notification", NotificationManager.IMPORTANCE_LOW);
+                    channel.setDescription("Shows the progress of a download");
+                } else {
+                    channel = maybeProgressChannel;
+                }
+                break;
+            case ANOTHER_LIVE_NOTIFICATION:
+                NotificationChannel maybeAnotherChannel = notificationManager.getNotificationChannel(ANOTHER_CHANNEL_ID);
+                if (maybeAnotherChannel == null) {
+                    channel = new NotificationChannel(ANOTHER_CHANNEL_ID, "Another Live Notification", NotificationManager.IMPORTANCE_LOW);
+                    channel.setDescription("Whatever you like");
+                } else {
+                    channel = maybeAnotherChannel;
+                }
+                break;
+            default:
+                throw new IllegalStateException("Unexpected live notification type id: " + liveNotificationTypeId);
         }
+
+        notificationManager.createNotificationChannel(channel);
     }
 }

--- a/app/src/main/java/com/onesignal/sample/android/NotificationServiceExtension.java
+++ b/app/src/main/java/com/onesignal/sample/android/NotificationServiceExtension.java
@@ -5,6 +5,8 @@ import com.onesignal.notifications.IDisplayableMutableNotification;
 import com.onesignal.notifications.INotificationReceivedEvent;
 import com.onesignal.notifications.INotificationServiceExtension;
 
+import org.json.JSONException;
+
 public class NotificationServiceExtension implements INotificationServiceExtension {
     @Override
     public void onNotificationReceived(INotificationReceivedEvent event) {
@@ -19,9 +21,26 @@ public class NotificationServiceExtension implements INotificationServiceExtensi
         // this is an example of how to modify the notification by changing the background color to blue
         notification.setExtender(builder -> builder.setColor(0xFF0000FF));
         notification.setExtender(builder -> builder.setAutoCancel(false));
+        try {
+            // We could check some property on the notification that we set to determine
+            // whether the notification should be cancelled.
+            // Ex uses "OSAction": "stop"
+            // We could potentially use `dismissal_date` to determine to cancel
+            if (event.getNotification().getAdditionalData().get("OSAction") == "stop") {
+                // We can get the notification ID from the event itself
+                int notificationId = Integer.parseInt(event.getNotification().getNotificationId());
 
-        //If you need to perform an async action or stop the payload from being shown automatically,
-        //use event.preventDefault(). Using event.notification.display() will show this message again.
+                // Does our SDK provide a hook into this?
+                // My assumption is the SDK has a manager to manage all incoming OneSignal notifications
+
+                // NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+                // Assuming we can cancel
+                //notificationManager.cancel(notificationId);
+            }
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+
     }
 }
 

--- a/app/src/main/java/com/onesignal/sample/android/NotificationServiceExtension.java
+++ b/app/src/main/java/com/onesignal/sample/android/NotificationServiceExtension.java
@@ -26,7 +26,7 @@ public class NotificationServiceExtension implements INotificationServiceExtensi
             // whether the notification should be cancelled.
             // Ex uses "OSAction": "stop"
             // We could potentially use `dismissal_date` to determine to cancel
-            if (event.getNotification().getAdditionalData().get("OSAction") == "stop") {
+            if (event.getNotification().getAdditionalData().get("os_action") == "stop") {
                 // We can get the notification ID from the event itself
                 int notificationId = Integer.parseInt(event.getNotification().getNotificationId());
 

--- a/app/src/main/java/com/onesignal/sample/android/NotificationServiceExtension.java
+++ b/app/src/main/java/com/onesignal/sample/android/NotificationServiceExtension.java
@@ -14,40 +14,49 @@ import com.onesignal.notifications.INotificationServiceExtension;
 
 import org.json.JSONException;
 
+import java.util.Objects;
+
 public class NotificationServiceExtension implements INotificationServiceExtension {
     private static final String CHANNEL_ID = "progress_channel";
 
     @Override
     public void onNotificationReceived(INotificationReceivedEvent event) {
         IDisplayableMutableNotification notification = event.getNotification();
+        Context context = event.getContext(); // Assuming there's a way to obtain context
+        createNotificationChannel(context);
+        NotificationCompat.Builder builder;
+
         try {
-            String William = notification.getAdditionalData().get("live_notification_key").toString();
-            System.out.println(William);
+            String liveNotificationKey = Objects.requireNonNull(notification.getAdditionalData()).get("live_notification_key").toString();
+            switch (liveNotificationKey) {
+                case "some_id":
+                    int progressMax = 100;
+                    int currentProgress = 50; // This would be dynamically updated in a real scenario
+
+                    builder = new NotificationCompat.Builder(context, CHANNEL_ID)
+                            .setContentTitle("Android Live Notifications is in progress")
+                            .setContentText("Elly is working...")
+                            .setSmallIcon(android.R.drawable.ic_media_play)
+                            .setLargeIcon(BitmapFactory.decodeResource(context.getResources(), android.R.drawable.ic_dialog_info))
+                            .setOngoing(true)
+                            .setOnlyAlertOnce(true)
+                            .setProgress(progressMax, currentProgress, false);
+
+                    NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+                    notificationManager.notify(1, builder.build()); // ID 1 is arbitrary
+
+                    // As the download progresses, you would need to update the progress like so:
+                    // builder.setProgress(progressMax, newCurrentProgress, false);
+                    // notificationManager.notify(1, builder.build());
+                    break;
+                case "some_other_id":
+                    break;
+                default:
+                    throw new IllegalStateException("Unsupported Live Notification Key provided: " + liveNotificationKey);
+            }
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }
-        Context context = event.getContext(); // Assuming there's a way to obtain context
-        createNotificationChannel(context);
-
-        // Simulated download progress
-        int progressMax = 100;
-        int currentProgress = 50; // This would be dynamically updated in a real scenario
-
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, CHANNEL_ID)
-                .setContentTitle("Android Live Notifications is in progress")
-                .setContentText("Elly is working...")
-                .setSmallIcon(android.R.drawable.ic_media_play)
-                .setLargeIcon(BitmapFactory.decodeResource(context.getResources(), android.R.drawable.ic_dialog_info))
-                .setOngoing(true)
-                .setOnlyAlertOnce(true)
-                .setProgress(progressMax, currentProgress, false);
-
-        NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-        notificationManager.notify(1, builder.build()); // ID 1 is arbitrary
-
-        // As the download progresses, you would need to update the progress like so:
-        // builder.setProgress(progressMax, newCurrentProgress, false);
-        // notificationManager.notify(1, builder.build());
     }
 
     private void createNotificationChannel(Context context) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.0.2' apply false
-    id 'com.android.library' version '8.0.2' apply false
+    id 'com.android.application' version '8.3.2' apply false
+    id 'com.android.library' version '8.3.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.21' apply false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.0.2' apply false
-    id 'com.android.library' version '8.0.2' apply false
+    id 'com.android.application' version '8.3.1' apply false
+    id 'com.android.library' version '8.3.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.21' apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri May 19 13:42:53 PDT 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This document contains a high-level overview of how we could cancel an existing Live Update. It's not clear how this could happen, so I've included comments explaining an approach. We have a question:

* Does the SDK need to be updated to support this?

###### Example payload

```json
{
  "to" : "device_token",
  "data" : {
    "os_action" : "stop",
    "notificationId" : "123"
  }
}
```